### PR TITLE
Integration testing and jacoco test coverage

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
   <component name="ProjectType">
     <option name="id" value="Android" />
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,12 @@
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.util.Properties
+jacoco {
+    toolVersion = "0.8.10"
+}
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    id("jacoco")
 }
 
 
@@ -41,6 +46,9 @@ android {
                 "proguard-rules.pro"
             )
         }
+        debug {
+            enableUnitTestCoverage = true
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -51,8 +59,15 @@ android {
         buildConfig = true
     }
     testOptions {
+        unitTests.all {
+            it.extensions.configure<JacocoTaskExtension> {
+                isIncludeNoLocationClasses = true
+                excludes = listOf("jdk.internal.*")
+            }
+        }
         unitTests {
             isIncludeAndroidResources = true
+            isReturnDefaultValues = true
         }
     }
 }
@@ -78,4 +93,42 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    testImplementation(kotlin("test"))
+    testImplementation("org.json:json:20240303")
+}
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+    }
+
+    val fileFilter = listOf(
+        "**/*Activity*.*",
+        "**/*Composable*.*",
+        "**/R.class", "**/R$*.class",
+        "**/BuildConfig.*", "**/Manifest*.*",
+        "**/*Test*.*"
+    )
+
+     val mainClasses = fileTree(
+        "$buildDir/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes"
+    ) {
+        exclude(fileFilter)
+    }
+
+    classDirectories.setFrom(files(mainClasses))
+    sourceDirectories.setFrom(files(
+        "src/main/java",
+        "src/main/kotlin"
+    ))
+
+    executionData.setFrom(fileTree(buildDir) {
+        include(
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/unit_test_code_coverage/debugUnitTest/*.exec"
+        )
+    })
 }

--- a/app/src/main/java/com/soen345/ticketreservation/data/AuthClient.kt
+++ b/app/src/main/java/com/soen345/ticketreservation/data/AuthClient.kt
@@ -1,6 +1,5 @@
 package com.soen345.ticketreservation.data
 
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -13,9 +12,9 @@ import com.soen345.ticketreservation.BuildConfig
 object AuthClient {
 
     private const val TAG = "AUTH"
-    internal var BASE_URL = BuildConfig.SUPABASE_URL      // ← use BuildConfig
-    private val ANON_KEY = BuildConfig.SUPABASE_ANON_KEY  // ← use BuildConfig
-
+    // AFTER — safe, falls back to empty string if anything goes wrong
+    internal var BASE_URL: String = runCatching { BuildConfig.SUPABASE_URL as? String }.getOrNull() ?: ""
+    internal var ANON_KEY: String = runCatching { BuildConfig.SUPABASE_ANON_KEY as? String }.getOrNull() ?: ""
     internal var http: OkHttpClient = OkHttpClient()
 
     data class AuthSession(
@@ -27,28 +26,24 @@ object AuthClient {
     suspend fun signUp(email: String, password: String): Pair<Int, String> = withContext(Dispatchers.IO) {
         try {
             val url = "$BASE_URL/auth/v1/signup"
-
             val json = JSONObject().apply {
                 put("email", email)
                 put("password", password)
             }
-
-            Log.d(TAG, "Using BASE_URL=$BASE_URL")
-
+            println("[$TAG] Using BASE_URL=$BASE_URL")
             val req = Request.Builder()
                 .url(url)
                 .post(json.toString().toRequestBody("application/json".toMediaType()))
                 .addHeader("apikey", ANON_KEY)
                 .addHeader("Content-Type", "application/json")
                 .build()
-
             http.newCall(req).execute().use { resp ->
                 val body = resp.body?.string().orEmpty()
-                Log.d(TAG, "signUp code=${resp.code} body=$body")
+                println("[$TAG] signUp code=${resp.code} body=$body")
                 resp.code to body
             }
         } catch (e: Exception) {
-            Log.e(TAG, "signUp crashed", e)
+            println("[$TAG] signUp crashed: ${e.message}")
             0 to (e.message ?: "error")
         }
     }
@@ -56,36 +51,30 @@ object AuthClient {
     suspend fun signIn(email: String, password: String): AuthSession? = withContext(Dispatchers.IO) {
         try {
             val url = "$BASE_URL/auth/v1/token?grant_type=password"
-
             val json = JSONObject().apply {
                 put("email", email)
                 put("password", password)
             }
-
             val req = Request.Builder()
                 .url(url)
                 .post(json.toString().toRequestBody("application/json".toMediaType()))
                 .addHeader("apikey", ANON_KEY)
                 .addHeader("Content-Type", "application/json")
                 .build()
-
             http.newCall(req).execute().use { resp ->
                 val body = resp.body?.string().orEmpty()
-                Log.d(TAG, "signIn code=${resp.code} body=$body")
-
+                println("[$TAG] signIn code=${resp.code} body=$body")
                 if (!resp.isSuccessful) return@withContext null
-
                 val obj = JSONObject(body)
                 val accessToken = obj.optString("access_token", "")
                 val userObj = obj.optJSONObject("user")
                 val userId = userObj?.optString("id", "") ?: ""
                 val em = userObj?.optString("email", "") ?: email
-
                 if (accessToken.isBlank() || userId.isBlank()) return@withContext null
                 AuthSession(userId, em, accessToken)
             }
         } catch (e: Exception) {
-            Log.e(TAG, "signIn crashed", e)
+            println("[$TAG] signIn crashed: ${e.message}")
             null
         }
     }
@@ -94,7 +83,6 @@ object AuthClient {
         try {
             val url = "$BASE_URL/auth/v1/logout"
             val emptyBody = "{}".toRequestBody("application/json".toMediaType())
-
             val req = Request.Builder()
                 .url(url)
                 .post(emptyBody)
@@ -102,14 +90,13 @@ object AuthClient {
                 .addHeader("Authorization", "Bearer $accessToken")
                 .addHeader("Content-Type", "application/json")
                 .build()
-
             http.newCall(req).execute().use { resp ->
                 val body = resp.body?.string().orEmpty()
-                Log.d(TAG, "signOut code=${resp.code} body=$body")
+                println("[$TAG] signOut code=${resp.code} body=$body")
                 resp.code to body
             }
         } catch (e: Exception) {
-            Log.e(TAG, "signOut crashed", e)
+            println("[$TAG] signOut crashed: ${e.message}")
             0 to (e.message ?: "")
         }
     }

--- a/app/src/test/java/com/soen345/ticketreservation/data/AuthClientIntegrationTest.kt
+++ b/app/src/test/java/com/soen345/ticketreservation/data/AuthClientIntegrationTest.kt
@@ -1,0 +1,262 @@
+package com.soen345.ticketreservation.data
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+
+class AuthClientIntegrationTest {
+
+    private lateinit var mockWebServer: MockWebServer
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        val raw = mockWebServer.url("/").toString()
+        AuthClient.BASE_URL = if (raw.endsWith("/")) raw.dropLast(1) else raw
+        AuthClient.ANON_KEY = "test-anon-key"
+        AuthClient.http = OkHttpClient()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `signUp success returns 200`() : Unit= runBlocking {
+        println("BASE_URL = ${AuthClient.BASE_URL}")  // check this in test output
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"id":"user-123","email":"test@test.com"}""")
+        )
+
+        val (code, _) = AuthClient.signUp("test@test.com", "password123")
+        assertEquals(200, code)
+    }
+
+    @Test
+    fun `signIn success returns valid session`(): Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""
+                    {
+                      "access_token": "tok123",
+                      "user": {
+                        "id": "user-123",
+                        "email": "test@test.com"
+                      }
+                    }
+                """.trimIndent())
+        )
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+        assertNotNull(session)
+        assertEquals("tok123", session!!.accessToken)
+        assertEquals("user-123", session!!.userId)
+    }
+
+    @Test
+    fun `signIn failure returns null`(): Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .setBody("""{"error":"invalid_credentials"}""")
+        )
+
+        val session = AuthClient.signIn("wrong@test.com", "wrongpass")
+        assertNull(session)
+    }
+
+    @Test
+    fun `signUp then signIn full flow`(): Unit = runBlocking {
+        // signup
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"id":"user-456","email":"new@test.com"}""")
+        )
+        // signin
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""
+                    {
+                      "access_token": "newtoken",
+                      "user": {
+                        "id": "user-456",
+                        "email": "new@test.com"
+                      }
+                    }
+                """.trimIndent())
+        )
+
+        val (code, _) = AuthClient.signUp("new@test.com", "password123")
+        assertEquals(200, code)
+
+        val session = AuthClient.signIn("new@test.com", "password123")
+        assertNotNull(session)
+        assertEquals("newtoken", session!!.accessToken)
+    }
+
+    @Test
+    fun `signOut success returns 200`(): Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("{}")
+        )
+
+        val (code, _) = AuthClient.signOut("tok123")
+        assertEquals(200, code)
+    }
+
+    @Test
+    fun `signIn network failure returns null`() : Unit = runBlocking {
+        // Shut down server to simulate network failure
+        mockWebServer.shutdown()
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+
+        assertNull(session)
+    }
+
+    @Test
+    fun `signIn invalid JSON returns null`() : Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("INVALID_JSON")
+        )
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+
+        assertNull(session)
+    }
+
+    @Test
+    fun `signIn empty response returns null`() : Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("{}")
+        )
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+
+        assertNull(session)
+    }
+
+
+    @Test
+    fun `signUp failure returns non 200`() : Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"error":"bad_request"}""")
+        )
+
+        val (code, _) = AuthClient.signUp("bad@test.com", "123")
+
+        assertEquals(400, code)
+    }
+
+
+    @Test
+    fun `signOut failure returns non 200`() : Unit = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .setBody("""{"error":"unauthorized"}""")
+        )
+
+        val (code, _) = AuthClient.signOut("invalid-token")
+
+        assertEquals(401, code)
+    }
+
+    @Test
+    fun `signIn missing token returns null`() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""
+                {
+                  "user": {
+                    "id": "user-123"
+                  }
+                }
+            """.trimIndent())
+        )
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+
+        assertNull(session)
+    }
+
+    @Test
+    fun `signIn missing user returns null`() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"access_token": "tok123"}""")
+        )
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+
+        assertNull(session)
+    }
+
+    @Test
+    fun `signIn missing user id returns null`() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""
+                {
+                  "access_token": "tok123",
+                  "user": {}
+                }
+            """.trimIndent())
+        )
+
+        val session = AuthClient.signIn("test@test.com", "password123")
+
+        assertNull(session)
+    }
+    @Test
+    fun `signUp empty body still returns code`() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("")
+        )
+
+        val (code, body) = AuthClient.signUp("test@test.com", "pass")
+
+        assertEquals(200, code)
+    }
+
+    @Test
+    fun `signOut empty response still returns code`() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("")
+        )
+
+
+        val (code, _) = AuthClient.signOut("tok123")
+
+        assertEquals(200, code)
+    }
+}

--- a/app/src/test/java/com/soen345/ticketreservation/data/SupabaseClientTest.kt
+++ b/app/src/test/java/com/soen345/ticketreservation/data/SupabaseClientTest.kt
@@ -175,4 +175,35 @@ class SupabaseClientTest {
         Assert.assertTrue("Expected success message but got: ${msg}", msg.contains("Ticket email sent", ignoreCase = true))
     }
 
+    @Test
+    fun `fetchEvents returns error on failure`() = runBlocking {
+        mockServer.enqueue(
+            MockResponse().setResponseCode(500)
+        )
+
+        val result = SupabaseClient.fetchEvents("fake-token", "user1")
+
+        Assert.assertNotNull(result.errorMessage)
+        Assert.assertNull(result.events)
+    }
+
+    @Test
+    fun `upsertUserProfile returns error code`() {
+        mockServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"error":"bad request"}""")
+        )
+
+        val (code, _) = SupabaseClient.upsertUserProfile(
+            "fake-token", "123", "test@test.com", null, null
+        )
+
+        Assert.assertEquals(400, code)
+    }
 }
+
+
+
+
+


### PR DESCRIPTION
### Description

This PR introduces **integration testing** with a focus on the `AuthClientIntegrationTest` to validate authentication flows, along with **JaCoCo coverage reporting**.

### Key Changes

* Added `AuthClientIntegrationTest` to test:

  * Sign up, sign in, and sign out flows
  * Success and failure scenarios
* Used **MockWebServer** to simulate backend behavior
* Added additional tests to improve coverage

### Coverage

* Configured **JaCoCo** for test coverage reporting
* Focused on data and logic layers

### Testing

```bash
./gradlew clean testDebugUnitTest jacocoTestReport
```

### Checklist

* [x] AuthClient integration tests added
* [x] Coverage configured
* [x] All tests passing
